### PR TITLE
Fix crash when playlist images are missing

### DIFF
--- a/client/src/components/AddModal/AddModal.tsx
+++ b/client/src/components/AddModal/AddModal.tsx
@@ -69,7 +69,7 @@ export const AddModal: React.FC<IAddModalProps> = ({ trackUri, onClose }) => {
                     id={playlist.id}
                     title={playlist.name}
                     secondaryText={`by ${playlist.owner.display_name}`}
-                    cover={playlist.images[0]}
+                    cover={playlist.images?.[0]}
                     handleClick={() => onAddClick(playlist.id)}
                   />
                 ))

--- a/client/src/components/CheckSong/CheckSong.tsx
+++ b/client/src/components/CheckSong/CheckSong.tsx
@@ -77,7 +77,7 @@ export const CheckSong = () => {
           id={track.id}
           title={track.name}
           secondaryText={`by ${track.artists.map((a) => a.name).toString()}`}
-          cover={track.album.images[0]}
+          cover={track.album.images?.[0]}
         // handleClick={() => setCurrentPlayback()}
         >
           <div style={{ color: "white", display: "flex", alignItems: "center" }}>
@@ -94,7 +94,7 @@ export const CheckSong = () => {
             id={t.id}
             title={t.name}
             secondaryText={`by ${t.artists.map((a) => a.name).toString()}`}
-            cover={t.album.images[0]}
+            cover={t.album.images?.[0]}
             isChecked={t.id === track?.id}
             handleClick={() => {
               setTrack(t);
@@ -115,7 +115,7 @@ export const CheckSong = () => {
                 pt.items.find((i) => i.track.id === track.id || `${i.track.name}:${(i.track as SpotifyApi.TrackObjectFull).artists[0].name}`.toLowerCase() === `${track.name}:${track.artists[0].name}`.toLowerCase())
                   ?.added_at as string
               ).toLocaleDateString()}`}
-              cover={pt.playlist.images[0]}
+              cover={pt.playlist.images?.[0]}
               handleClick={() => window.location.href = pt.playlist.external_urls.spotify}
             />
           ))}

--- a/client/src/components/ListResult/ListResult.tsx
+++ b/client/src/components/ListResult/ListResult.tsx
@@ -5,7 +5,7 @@ import styles from "./ListResult.module.scss";
 export interface IListResultProps {
   id: string;
   title: string;
-  cover: SpotifyApi.ImageObject;
+  cover?: SpotifyApi.ImageObject;
   secondaryText?: string;
   tertiaryText?: string;
   isChecked?: boolean;
@@ -31,11 +31,11 @@ export const ListResult: React.FC<IListResultProps> = ({
       <div className={styles.overlay}>
         <img
           className={styles.cover}
-          src={cover?.url}
+          src={cover?.url ?? ""}
           alt="cover"
           height={60}
           width={60}
-        ></img>
+        />
         <div className={styles.textWrapper}>
           <h5>{title}</h5>
           {secondaryText && (

--- a/client/src/components/PlaylistCombiner/PlaylistCombiner.tsx
+++ b/client/src/components/PlaylistCombiner/PlaylistCombiner.tsx
@@ -83,7 +83,7 @@ export const PlaylistCombiner = () => {
                   id={playlist.id}
                   title={playlist.name}
                   secondaryText={`by ${playlist.owner.display_name}`}
-                  cover={playlist.images[0]}
+                  cover={playlist.images?.[0]}
                   isChecked={selectedPlaylists.includes(playlist)}
                   handleClick={!loading ? handelSelectedPlaylists : undefined}
                 />

--- a/client/src/services/SpotifyService.ts
+++ b/client/src/services/SpotifyService.ts
@@ -27,9 +27,16 @@ export default class SpotifyService implements ISpotifyService {
         limit: 50, //max limit
         offset,
       });
-      return res.items.length + offset === res.total
-        ? res.items
-        : [...res.items, ...(await getPlaylistsRecursive(offset + 50))];
+      const normalizedItems = res.items.map((playlist) => ({
+        ...playlist,
+        images: playlist.images ?? [],
+      }));
+      return normalizedItems.length + offset === res.total
+        ? normalizedItems
+        : [
+            ...normalizedItems,
+            ...(await getPlaylistsRecursive(offset + 50)),
+          ];
     };
     return getPlaylistsRecursive(0);
   }


### PR DESCRIPTION
## Summary
- Prevent crash when a playlist/album has no images by using safe access (`images?.[0]`).
- Make `ListResult` cover optional and render an empty `src` when missing to keep alignment.
- Normalize playlist `images` in `SpotifyService.getPlaylists()` to an empty array when null.

## Test plan
- Open `/merge-playlists` with at least one playlist that has no cover image; confirm page does not crash and list alignment looks consistent.
- Open Add-to-playlist modal; confirm playlists without images render and remain selectable.
- Open `/check-song`; confirm track and playlist results render even if images are missing.

Made with [Cursor](https://cursor.com)