### PR TITLE
UI: full-width list scrollbars

### DIFF
--- a/client/src/components/LikeCatalog/LikeCatalog.module.scss
+++ b/client/src/components/LikeCatalog/LikeCatalog.module.scss
@@ -66,3 +66,31 @@
     }
   }
 }
+
+.scroller {
+  overflow-y: auto;
+  overflow-x: hidden;
+
+  // Full-bleed scroller so the scrollbar reaches the window edge,
+  // while list items stay centered via rowInner below.
+  width: 100vw;
+  margin-left: calc(50% - 50vw);
+}
+
+.virtualContainer {
+  width: 100%;
+  position: relative;
+}
+
+.rowOuter {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.rowInner {
+  width: 100%;
+  max-width: 800px;
+  padding: 0 1em;
+  box-sizing: border-box;
+}

--- a/client/src/components/LikeCatalog/LikeCatalog.tsx
+++ b/client/src/components/LikeCatalog/LikeCatalog.tsx
@@ -66,16 +66,15 @@ export const LikeCatalog = () => {
       </p>
       {!!likedTracksFiltered ? <div
         ref={parentRef}
+        className={styles.scroller}
         style={{
           height: listHeight,
-          overflow: 'auto', // Make it scroll!
         }}
       >
         <div
+          className={styles.virtualContainer}
           style={{
             height: `${rowVirtualizer.getTotalSize()}px`,
-            width: '100%',
-            position: 'relative',
           }}
         >
           {rowVirtualizer.getVirtualItems().map((virtualItem) => {
@@ -83,37 +82,39 @@ export const LikeCatalog = () => {
             return (
               <div
                 key={virtualItem.key}
+                className={styles.rowOuter}
                 style={{
                   position: 'absolute',
                   top: 0,
                   left: 0,
-                  width: '100%',
                   transform: `translateY(${virtualItem.start}px)`,
                 }}
               >
-                <ListResult
-                  key={track.id + virtualItem.index}
-                  id={track.id}
-                  title={track.name}
-                  secondaryText={`by ${track.artists
-                    .map((a) => a.name)
-                    .toString()}`}
-                  cover={track.album.images[0]}
-                  handleClick={() => spotifyService?.playTrack(track)}
-                >
-                  <div style={{ display: "flex", alignItems: "center" }}>
-                    <ThreeDots
-                      width={32}
-                      height={32}
-                      style={{ fill: "white", padding: "6px 3px" }}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setTrackUri(track.uri)
-                        setShowAddModal(true)
-                      }}
-                    />
-                  </div>
-                </ListResult>
+                <div className={styles.rowInner}>
+                  <ListResult
+                    key={track.id + virtualItem.index}
+                    id={track.id}
+                    title={track.name}
+                    secondaryText={`by ${track.artists
+                      .map((a) => a.name)
+                      .toString()}`}
+                    cover={track.album.images[0]}
+                    handleClick={() => spotifyService?.playTrack(track)}
+                  >
+                    <div style={{ display: "flex", alignItems: "center" }}>
+                      <ThreeDots
+                        width={32}
+                        height={32}
+                        style={{ fill: "white", padding: "6px 3px" }}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setTrackUri(track.uri)
+                          setShowAddModal(true)
+                        }}
+                      />
+                    </div>
+                  </ListResult>
+                </div>
               </div>
             )
           })}

--- a/client/src/components/PlaylistCombiner/PlaylistCombiner.module.scss
+++ b/client/src/components/PlaylistCombiner/PlaylistCombiner.module.scss
@@ -19,13 +19,6 @@
     margin-right: 1vw;
   }
 
-  > p {
-    align-self: center;
-    margin-bottom: 1em;
-    margin-left: 1em;
-    margin-right: 1em;
-  }
-
   .loginButton {
     margin-top: 2em;
     align-self: center;
@@ -49,12 +42,19 @@
       display: flex;
       flex-direction: column;
       width: 100%;
-      margin-left: 1vw;
-      margin-right: 1vw;
       padding-top: 1vw;
 
       p {
         margin-top: 0px;
+      }
+
+      .header {
+        > p {
+          align-self: center;
+          margin-bottom: 1em;
+          margin-left: 1em;
+          margin-right: 1em;
+        }
       }
 
       .controls {
@@ -160,4 +160,22 @@
       }
     }
   }
+}
+
+.scroller {
+  overflow-y: auto;
+  overflow-x: hidden;
+
+  // Full-bleed scroller so the scrollbar reaches the window edge,
+  // while list items stay centered via scrollerInner below.
+  width: 100vw;
+  margin-left: calc(50% - 50vw);
+}
+
+.scrollerInner {
+  width: 100%;
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 0 1em;
+  box-sizing: border-box;
 }

--- a/client/src/components/PlaylistCombiner/PlaylistCombiner.tsx
+++ b/client/src/components/PlaylistCombiner/PlaylistCombiner.tsx
@@ -18,6 +18,22 @@ export const PlaylistCombiner = () => {
   const [filter, setFilter] = useState("");
   const [loading, setLoading] = useState(false)
 
+  const headerRef = React.useRef<HTMLDivElement>(null)
+  const [listHeight, setListHeight] = useState(200)
+
+  useEffect(() => {
+    const check = () => {
+      if (headerRef.current) {
+        const { bottom } = headerRef.current.getBoundingClientRect()
+        setListHeight(window.innerHeight - bottom - 20)
+      }
+    }
+
+    check()
+    window.addEventListener("resize", check)
+    return () => window.removeEventListener("resize", check)
+  }, [playlists, filter, loading])
+
   const onCreatePlaylistClick = async () => {
     setLoading(true)
     const url = await spotifyService?.queuePlaylists(selectedPlaylists);
@@ -49,56 +65,62 @@ export const PlaylistCombiner = () => {
 
   return (
     <div className={styles.playlistCombiner}>
-      <p>
-        Select the playlists you want to merge. Duplicate songs will be filtered.
-      </p>
       <div className={styles.horWraper}>
         <div className={styles.playlistRows}>
-          <div className={styles.controls}>
-            <input
-              type="search"
-              className={styles.filter}
-              placeholder="Filter"
-              value={filter}
-              onChange={(e) => {
-                setFilter(e.target.value);
-              }}
-            />
-            <button className={styles.clearBtn} onClick={clearSelection}>
-              Clear
-            </button>
-          </div>
-          {!!playlists && playlists.length > 0 ? (
-            playlists
-              .filter(
-                (p) =>
-                  p.name.toLowerCase().includes(filter.toLowerCase()) ||
-                  p.owner.display_name
-                    ?.toLowerCase()
-                    .includes(filter.toLowerCase())
-              )
-              .map((playlist, key) => (
-                <ListResult
-                  key={key}
-                  id={playlist.id}
-                  title={playlist.name}
-                  secondaryText={`by ${playlist.owner.display_name}`}
-                  cover={playlist.images?.[0]}
-                  isChecked={selectedPlaylists.includes(playlist)}
-                  handleClick={!loading ? handelSelectedPlaylists : undefined}
-                />
-              ))
-          ) : (
-            <div className={styles.loadingPlaylists}>
-              <ClipLoader
-                cssOverride={{alignSelf: 'center'}}
-                size={30}
-                color={"#1db954"}
-                loading={true}
+          <div ref={headerRef} className={styles.header}>
+            <p>
+              Select the playlists you want to merge. Duplicate songs will be filtered.
+            </p>
+            <div className={styles.controls}>
+              <input
+                type="search"
+                className={styles.filter}
+                placeholder="Filter"
+                value={filter}
+                onChange={(e) => {
+                  setFilter(e.target.value);
+                }}
               />
-              <span>Loading playlists...</span>
+              <button className={styles.clearBtn} onClick={clearSelection}>
+                Clear
+              </button>
             </div>
-          )}
+          </div>
+          <div className={styles.scroller} style={{ height: listHeight }}>
+            <div className={styles.scrollerInner}>
+              {!!playlists && playlists.length > 0 ? (
+                playlists
+                  .filter(
+                    (p) =>
+                      p.name.toLowerCase().includes(filter.toLowerCase()) ||
+                      p.owner.display_name
+                        ?.toLowerCase()
+                        .includes(filter.toLowerCase())
+                  )
+                  .map((playlist, key) => (
+                    <ListResult
+                      key={key}
+                      id={playlist.id}
+                      title={playlist.name}
+                      secondaryText={`by ${playlist.owner.display_name}`}
+                      cover={playlist.images?.[0]}
+                      isChecked={selectedPlaylists.includes(playlist)}
+                      handleClick={!loading ? handelSelectedPlaylists : undefined}
+                    />
+                  ))
+              ) : (
+                <div className={styles.loadingPlaylists}>
+                  <ClipLoader
+                    cssOverride={{ alignSelf: 'center' }}
+                    size={30}
+                    color={"#1db954"}
+                    loading={true}
+                  />
+                  <span>Loading playlists...</span>
+                </div>
+              )}
+            </div>
+          </div>
         </div>
         <button
           onClick={onCreatePlaylistClick}

--- a/client/src/components/RecentlyAdded/RecentlyAdded.module.scss
+++ b/client/src/components/RecentlyAdded/RecentlyAdded.module.scss
@@ -66,3 +66,31 @@
     }
   }
 }
+
+.scroller {
+  overflow-y: auto;
+  overflow-x: hidden;
+
+  // Full-bleed scroller (consistent 100vw math) so the scrollbar
+  // reaches the window edge while list items stay centered.
+  width: 100vw;
+  margin-left: calc(50% - 50vw);
+}
+
+.virtualContainer {
+  width: 100%;
+  position: relative;
+}
+
+.rowOuter {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.rowInner {
+  width: 100%;
+  max-width: 800px;
+  padding: 0 1em;
+  box-sizing: border-box;
+}

--- a/client/src/components/RecentlyAdded/RecentlyAdded.tsx
+++ b/client/src/components/RecentlyAdded/RecentlyAdded.tsx
@@ -60,16 +60,15 @@ export const RecentlyAdded = () => {
       </p>
       {recentlyAddedTracks && <div
         ref={parentRef}
+        className={styles.scroller}
         style={{
           height: listHeight,
-          overflow: 'auto', // Make it scroll!
         }}
       >
         <div
+          className={styles.virtualContainer}
           style={{
             height: `${rowVirtualizer.getTotalSize()}px`,
-            width: '100%',
-            position: 'relative',
           }}
         >
           {rowVirtualizer.getVirtualItems().map((virtualItem) => {
@@ -77,25 +76,27 @@ export const RecentlyAdded = () => {
             return (
               <div
                 key={virtualItem.key}
+                className={styles.rowOuter}
                 style={{
                   position: 'absolute',
                   top: 0,
                   left: 0,
-                  width: '100%',
                   transform: `translateY(${virtualItem.start}px)`,
                 }}
               >
-                <ListResult
-                  key={track.id + virtualItem.index}
-                  id={track.id}
-                  title={track.name}
-                  secondaryText={`by ${track.artists
-                    .map((a) => a.name)
-                    .toString()}`}
-                  tertiaryText={`Added to ${recentlyAddedTracks[virtualItem.index].playlistName}, ${dayjs().to(dayjs(recentlyAddedTracks[virtualItem.index].added_at))}`}
-                  handleClick={() => spotifyService?.playTrack(track)}
-                  cover={track.album.images[0]}
-                />
+                <div className={styles.rowInner}>
+                  <ListResult
+                    key={track.id + virtualItem.index}
+                    id={track.id}
+                    title={track.name}
+                    secondaryText={`by ${track.artists
+                      .map((a) => a.name)
+                      .toString()}`}
+                    tertiaryText={`Added to ${recentlyAddedTracks[virtualItem.index].playlistName}, ${dayjs().to(dayjs(recentlyAddedTracks[virtualItem.index].added_at))}`}
+                    handleClick={() => spotifyService?.playTrack(track)}
+                    cover={track.album.images[0]}
+                  />
+                </div>
               </div>
             )
           })}


### PR DESCRIPTION
## Summary
- Make virtualized lists (Recently Added, Like Catalog) use a full-bleed scroller so the scrollbar reaches the window edge while ListResult rows remain centered.
- Update Merge Playlists to keep the header/controls fixed and scroll only the entries list (also full-bleed scrollbar + centered content).

## Test plan
- Open Recently Added and verify scrollbar is at window edge; rows remain centered.
- Open Like Catalog and verify same behavior.
- Open Merge Playlists: header/controls stay put while playlist rows scroll; scrollbar at window edge.

Made with [Cursor](https://cursor.com)